### PR TITLE
Add script to automatically add owners

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ the current working directory.
 
 The root directory of the cloned repos can be specified in `config.ini`.
 
+## add-owners.js
+
+Adds all organization members as owners for each npm package. This will only work for packages of which you are already declared as the owner. For more information, see the [npm owner documentation](https://docs.npmjs.com/cli/owner).
+
 ## config.ini
 
 This file is currently only used to set the root directory for all repos. An

--- a/add-owners.js
+++ b/add-owners.js
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+
+var github = require('github-repositories');
+var spawnSync = require('child_process').spawnSync;
+var expectedOwners = require('./owners.json').owners;
+
+var res = spawnSync('npm', ['whoami']);
+if (res.error) throw res.error;
+var me = res.stdout.toString().trim();
+
+var ignoredRepos = [
+  'boilerplate',
+  'www',
+  'meta',
+  'nuke'
+];
+
+github('jstransformers', function (err, data) {
+  if (err) throw err;
+  data.forEach(function (repo) {
+    if (ignoredRepos.indexOf(repo.name) !== -1) return;
+    var res = spawnSync('npm', ['owner', 'ls', repo.name]);
+    if (res.error) throw res.error;
+    var owners = res.stdout.toString().split('\n').map(function (owner) {
+      return owner.split(' ')[0];
+    }).filter(Boolean);
+    console.log(repo.name);
+    if (owners.indexOf(me) !== -1) {
+      expectedOwners.forEach(function (owner) {
+        if (owners.indexOf(owner) === -1) {
+          console.log(' - adding ' + owner);
+          var res = spawnSync('npm', ['owner', 'add', owner, repo.name]);
+          if (res.error) throw res.error;
+        }
+      });
+    } else {
+      console.log(' - not an owner');
+    }
+  });
+})


### PR DESCRIPTION
I’ve run this, myself, so there should no longer be any repos that I own but other people don’t.  There are some repos that I am not an owner of though, so it would be good if everyone could run this.